### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gulp -ws
 ## 第三方扩展
 
 - [kevyu/weui-sass](https://github.com/kevyu/weui-sass)
-- [Eric-Guo/weui-rails](https://rubygems.org/gems/weui-rails) (Using kevyu/weui-sass)
+- [Eric-Guo/weui-rails](https://github.com/Eric-Guo/weui-rails)(Using kevyu/weui-sass)
 - [n7best/react-weui](https://github.com/n7best/react-weui)
 - [aidenzou/vue-weui](https://github.com/aidenzou/vue-weui)
 


### PR DESCRIPTION
「第三方扩展」的 rails 扩展地址改为作者 Github 地址而不是 rubygem 地址，方便开发者阅读相关文档。