### PR TITLE
修复actionsheet蒙版不触发动画的bug

### DIFF
--- a/dist/example/example.js
+++ b/dist/example/example.js
@@ -135,18 +135,20 @@ $(function () {
                 var mask = $('#mask');
                 var weuiActionsheet = $('#weui_actionsheet');
                 weuiActionsheet.addClass('weui_actionsheet_toggle');
-                mask.show().addClass('weui_fade_toggle').one('click', function () {
+                mask.show()
+                    .focus()//加focus是为了触发一次页面的重排(reflow or layout thrashing),使mask的transition动画得以正常触发
+                    .addClass('weui_fade_toggle').one('click', function () {
                     hideActionSheet(weuiActionsheet, mask);
                 });
                 $('#actionsheet_cancel').one('click', function () {
                     hideActionSheet(weuiActionsheet, mask);
                 });
-                weuiActionsheet.unbind('transitionend').unbind('webkitTransitionEnd');
+                mask.unbind('transitionend').unbind('webkitTransitionEnd');
 
                 function hideActionSheet(weuiActionsheet, mask) {
                     weuiActionsheet.removeClass('weui_actionsheet_toggle');
                     mask.removeClass('weui_fade_toggle');
-                    weuiActionsheet.on('transitionend', function () {
+                    mask.on('transitionend', function () {
                         mask.hide();
                     }).on('webkitTransitionEnd', function () {
                         mask.hide();

--- a/src/example/example.js
+++ b/src/example/example.js
@@ -135,18 +135,20 @@ $(function () {
                 var mask = $('#mask');
                 var weuiActionsheet = $('#weui_actionsheet');
                 weuiActionsheet.addClass('weui_actionsheet_toggle');
-                mask.show().addClass('weui_fade_toggle').one('click', function () {
+                mask.show()
+                    .focus()//加focus是为了触发一次页面的重排(reflow or layout thrashing),使mask的transition动画得以正常触发
+                    .addClass('weui_fade_toggle').one('click', function () {
                     hideActionSheet(weuiActionsheet, mask);
                 });
                 $('#actionsheet_cancel').one('click', function () {
                     hideActionSheet(weuiActionsheet, mask);
                 });
-                weuiActionsheet.unbind('transitionend').unbind('webkitTransitionEnd');
+                mask.unbind('transitionend').unbind('webkitTransitionEnd');
 
                 function hideActionSheet(weuiActionsheet, mask) {
                     weuiActionsheet.removeClass('weui_actionsheet_toggle');
                     mask.removeClass('weui_fade_toggle');
-                    weuiActionsheet.on('transitionend', function () {
+                    mask.on('transitionend', function () {
                         mask.hide();
                     }).on('webkitTransitionEnd', function () {
                         mask.hide();


### PR DESCRIPTION
因为display属性不是有粒度的属性，所以当一个事件让display属性发生改变时，transition将不会触发。解决的办法是触发在切换display属性之后，强行触发一次页面的重排(reflow)。

所以使用foucus()在切换display之后触发一次reflow。