### PR TITLE
修复tabbar使用weui-icon错位

### DIFF
--- a/src/style/widget/weui-tab/tabbar.less
+++ b/src/style/widget/weui-tab/tabbar.less
@@ -33,10 +33,15 @@
     display: inline-block;
     width: 24px;
     height: 24px;
+    line-height: 1em;
 
     i&, > i {
         font-size: 24px;
         color: @weuiTextColorGray;
+        &:before {
+            margin: 0;
+            vertical-align: top;
+        }
     }
 
     img {


### PR DESCRIPTION
searchBar 中 weui-tabbar__icon 用 icon 代替图片会错位
![qq 20161009115715](https://cloud.githubusercontent.com/assets/8612580/19217818/9572405c-8e17-11e6-8ea8-307b6bae201a.png)
